### PR TITLE
feat(auth & account routes): disable attempted OAuth2 implementation

### DIFF
--- a/backend/src/api/routes/pokemon_image.py
+++ b/backend/src/api/routes/pokemon_image.py
@@ -10,7 +10,6 @@ from src.api.dependency.crud import get_crud
 from src.api.dependency.header import get_auth_current_user
 from src.models.db.account import Account
 from src.models.schema.account import (
-    AccountInOAuthSignIn,
     AccountInRead,
     AccountInSignin,
     AccountInSignout,
@@ -22,7 +21,6 @@ from src.models.schema.pokemon_image import PokemonImageInCreate, PokemonImageIn
 from src.repository.crud.account import AccountCRUDRepository
 from src.repository.crud.pokemon_image import PokemonImageCRUDRepository
 from src.repository.crud.profile import ProfileCRUDRepository
-from src.security.authorizations.oauth2 import oauth2_get_current_user
 from src.utility.exceptions.custom import EntityDoesNotExist
 from src.utility.exceptions.database import DatabaseError
 from src.utility.exceptions.http.exc_400 import http_exc_400_bad_request
@@ -77,7 +75,7 @@ async def get_profiles(
 async def upload_pokemon_image(
     pokemon_image_create: PokemonImageInCreate = fastapi.Body(..., embed=True),
     pokemon_image_repo: PokemonImageCRUDRepository = fastapi.Depends(get_crud(repo_type=PokemonImageCRUDRepository)),
-    current_account: Account = fastapi.Depends(oauth2_get_current_user),
+    current_account: Account = fastapi.Depends(get_auth_current_user()),
 ) -> PokemonImageInResponse:
     loguru.logger.info("getting current_profile")
     current_profile = current_account.profile

--- a/backend/src/models/schema/account.py
+++ b/backend/src/models/schema/account.py
@@ -34,11 +34,6 @@ class AccountInSignup(BaseSchemaModel):
         return v
 
 
-class AccountInOAuthSignIn(BaseSchemaModel):
-    username: str
-    password: str
-
-
 class AccountInSignin(BaseSchemaModel):
     username: str
     password: str

--- a/backend/src/repository/crud/account.py
+++ b/backend/src/repository/crud/account.py
@@ -12,7 +12,6 @@ from sqlalchemy.sql import functions as sqlalchemy_functions
 
 from src.models.db.account import Account
 from src.models.schema.account import (
-    AccountInOAuthSignIn,
     AccountInRead,
     AccountInSignin,
     AccountInSignout,
@@ -247,31 +246,6 @@ class AccountCRUDRepository(BaseCRUDRepository):
                 is_logged_in=True, credentials_validated_at=datetime.datetime.utcnow()
             ),
         )
-
-        # update_stmt = sqlalchemy.update(table=Account).where(Account.id == db_account.id).values(is_logged_in=True)
-        # await self.async_session.execute(statement=update_stmt)
-        # await self.async_session.commit()
-        # await self.async_session.refresh(instance=db_account)
-        # await self.async_session.close()
-        return db_account
-
-    async def signin_oauth_account(self, account_signin: AccountInOAuthSignIn) -> Account:
-        db_account = await self.read_account(account_in_read=AccountInRead(username=account_signin.username))
-
-        if not db_account:
-            raise EntityDoesNotExist(f"Wrong wrong username!")
-
-        if not db_account.is_verified:
-            raise AccountIsNotVerified("Account is not verified! Please verify your account first.")
-
-        if not db_account.is_password_verified(password=account_signin.password):
-            raise PasswordDoesNotMatch("Password does not match! Please try again.")
-
-        update_stmt = sqlalchemy.update(table=Account).where(Account.id == db_account.id).values(is_logged_in=True)
-        await self.async_session.execute(statement=update_stmt)
-        await self.async_session.commit()
-        await self.async_session.refresh(instance=db_account)
-        await self.async_session.close()
         return db_account
 
     async def signout_account(self, account_signout: AccountInSignout) -> Account:

--- a/backend/src/security/authorizations/oauth2.py
+++ b/backend/src/security/authorizations/oauth2.py
@@ -10,7 +10,7 @@ from src.security.authorizations.jwt import jwt_manager
 from src.utility.exceptions.http.exc_403 import http_exc_403_forbidden_request
 
 # in the documentation of FastAPI the root is simply named "/token"
-oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/validate_credentials_and_otp")
+oauth2_scheme = OAuth2PasswordBearer(tokenUrl="/api/v1/auth/token")
 
 
 async def oauth2_get_current_user(


### PR DESCRIPTION
### Reasoning

The attempted implementation of OAuth2 is using OAuth2 as an authentication method, not an authorization method.

I don't see the value in having this second authentication method, which is less secure than our normal authentication flow.

Less code to maintain is also good right? ^^
